### PR TITLE
[DON'T MERGE] formula: Add Formula for Quilt v0.1

### DIFF
--- a/Formula/quilt.rb
+++ b/Formula/quilt.rb
@@ -1,0 +1,21 @@
+class Quilt < Formula
+  desc "Deploy and manage microservices with JavaScript."
+  homepage "http://quilt.io"
+  url "https://github.com/quilt/quilt/archive/REPLACE_ME.tar.gz"
+  sha256 "REPLACE_ME"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    (buildpath/"src/github.com/quilt/quilt").install buildpath.children
+    cd "src/github.com/quilt/quilt" do
+      system "go", "build", "-o", "quilt"
+      bin.install "quilt"
+    end
+  end
+
+  test do
+    system "#{bin}/quilt", "version"
+  end
+end

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# homebrew-quilt
+
+This repository contains the [Homebrew](https://github.com/Homebrew/brew) tap for
+[Quilt](quilt.io).
+
+## Installation
+
+Install Homebrew, and run `brew install quilt/quilt/quilt`.
+
+## Updating a Release
+
+Modify the [formula](Formula/quilt.rb) so that `url` points to the source code
+tarball for the new release, and modify `sha256` to be its sha256 hash. Then,
+simply push the updated formula.
+
+The hash can be generated with the following command:
+```
+$ curl -sL $TARBALL_URL | shasum -a 256
+```


### PR DESCRIPTION
This patch creates a simple homebrew formula that allows users to
install Quilt on MacOS machines using brew.

This PR is to show an example brew formula for Quilt. Before merging, several release-specific lines will need to be changed:
- The URL (https://github.com/quilt/homebrew-quilt/compare/master...kklin:formula?expand=1#diff-5a51245fea427fdf07548ddf0d085dcfR4)
- The hash (https://github.com/kklin/homebrew-quilt/blob/35f518cd1682e8ef5f88e3a63b7b4229f3d8971e/Formula/quilt.rb#L5)
- The version in the commit message if it's not `v0.1`.

To test, push the fixed commit to the master branch of a repository. The repository must have the name `homebrew-quilt`. Then `brew install $REPO_USERNAME/quilt/quilt && brew test $REPO_USERNAME/quilt/quilt`, and ensure that `quilt` actually runs properly. `$REPO_USERNAME` for `github.com/kklin/homebrew-quilt` is `kklin`.